### PR TITLE
add System Access setting assesment back to analyze password policy

### DIFF
--- a/Group3r/Assessment/AnalyserFactory.cs
+++ b/Group3r/Assessment/AnalyserFactory.cs
@@ -124,11 +124,11 @@ namespace Group3r.Assessment
                 ShortcutSetting castSetting = (ShortcutSetting)setting;
                 return new ShortcutAnalyser() { setting = castSetting };
             }
-            //            else if (setting.GetType() == typeof(SystemAccessSetting))
-            //            {
-            //                SystemAccessSetting castSetting = (SystemAccessSetting)setting;
-            //                return new SystemAccessAnalyser() { setting = castSetting };
-            //            }
+            else if (setting.GetType() == typeof(SystemAccessSetting))
+            {
+                SystemAccessSetting castSetting = (SystemAccessSetting)setting;
+                return new SystemAccessAnalyser() { setting = castSetting };
+            }
             //            else if (setting.GetType() == typeof(UserSetting))
             //            {
             //                UserSetting castSetting = (UserSetting)setting;

--- a/Group3r/View/JsonGpoPrinter.cs
+++ b/Group3r/View/JsonGpoPrinter.cs
@@ -30,7 +30,7 @@ namespace Group3r.View
         jSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
-            Formatting = Formatting.Indented,
+            Formatting = Formatting.None, // turn off indented formatting for "true" JSONL style
             Converters = new List<JsonConverter>() { new StringEnumConverter() }
         };
     }

--- a/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/InfGpoFile.cs
+++ b/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/InfGpoFile.cs
@@ -120,6 +120,7 @@ namespace LibSnaffle.ActiveDirectory
                             lineKey = (splitLine[0]).Trim();
                         }
 
+                        Logger.Info("Encountered section heading: " + sectionHeading);
                         switch (sectionHeading)
                         {
                             case "Privilege Rights":


### PR DESCRIPTION
Uncomment some code to analyze `.inf` files for System Access rules, without which we can't parse domain password policy. Also update output format for (proper) JSONL.